### PR TITLE
Store preferred board in local config

### DIFF
--- a/lib/trello_flow.rb
+++ b/lib/trello_flow.rb
@@ -1,7 +1,6 @@
 require "trello_flow/version"
 require "trello_flow/cli"
 require "trello_flow/table"
-require "trello_flow/config"
 require "trello_flow/branch"
 require "trello_flow/cleanup"
 require "trello_flow/main"

--- a/lib/trello_flow/config.rb
+++ b/lib/trello_flow/config.rb
@@ -4,9 +4,16 @@ module TrelloFlow
   class Config
     PATH = ENV["HOME"] + "/.trello_flow"
 
-    def initialize(data = load_data || {})
-      @data = data
-      Api::Base.configure(key: key, token: token)
+    def initialize(data = nil)
+      @data = data || load_data
+    end
+
+    def key
+      @_key ||= data[:key] || configure_key
+    end
+
+    def token
+      @_token ||= data[:token] || configure_token
     end
 
     private
@@ -17,14 +24,6 @@ module TrelloFlow
         YAML.load(File.read(PATH))
       rescue
         false
-      end
-
-      def key
-        @_key ||= data[:key] || configure_key
-      end
-
-      def token
-        @_token ||= data[:token] || configure_token
       end
 
       def configure_key

--- a/lib/trello_flow/config_store.rb
+++ b/lib/trello_flow/config_store.rb
@@ -1,0 +1,32 @@
+module TrelloFlow
+  class ConfigStore
+    def initialize(path)
+      @path = path
+    end
+
+    def [](key)
+      data[key]
+    end
+
+    def save(key, value)
+      data[key] = value
+      File.new(path, "w") unless File.exists?(path)
+      File.open(path, "w") { |f| f.write(data.to_yaml) }
+      value
+    end
+
+    private
+
+      attr_reader :path
+
+      def data
+        @_data ||= load_data
+      end
+
+      def load_data
+        YAML.load File.read(path)
+      rescue
+        {}
+      end
+  end
+end

--- a/lib/trello_flow/local_config.rb
+++ b/lib/trello_flow/local_config.rb
@@ -1,0 +1,29 @@
+module TrelloFlow
+  class LocalConfig
+    PATH = ".trello_flow"
+
+    def initialize(store = nil)
+      @store = store || ConfigStore.new(PATH)
+    end
+
+    def board
+      @_board ||= Api::Board.find(board_id)
+    end
+
+    private
+
+      attr_reader :store
+
+      def board_id
+        @_board_id ||= store[:board_id] || configure_board_id
+      end
+
+      def configure_board_id
+        store.save :board_id, Table.pick(current_user.boards.active).id
+      end
+
+      def current_user
+        Api::Member.current
+      end
+  end
+end

--- a/lib/trello_flow/main.rb
+++ b/lib/trello_flow/main.rb
@@ -1,7 +1,7 @@
 module TrelloFlow
   class Main
     def initialize(config = Config.new)
-      @config = config
+      Api::Base.configure(key: config.key, token: config.token)
     end
 
     def start(name)

--- a/lib/trello_flow/main.rb
+++ b/lib/trello_flow/main.rb
@@ -1,7 +1,11 @@
+require "trello_flow/local_config"
+require "trello_flow/global_config"
+
 module TrelloFlow
   class Main
-    def initialize(config = Config.new)
-      Api::Base.configure(key: config.key, token: config.token)
+    def initialize(global_config = GlobalConfig.new, local_config = LocalConfig.new)
+      Api::Base.configure(key: global_config.key, token: global_config.token)
+      @local_config = local_config
     end
 
     def start(name)
@@ -28,6 +32,12 @@ module TrelloFlow
 
     private
 
+      attr_reader :local_config
+
+      def board
+        @_board ||= local_config.board
+      end
+
       def create_or_pick_card(name)
         if name.to_s.start_with?("http")
           Api::Card.find_by_url(name)
@@ -39,12 +49,10 @@ module TrelloFlow
       end
 
       def create_new_card(name)
-        board = Table.pick(current_user.boards.active)
         board.lists.backlog.cards.create name: name
       end
 
       def pick_existing_card
-        board = Table.pick(current_user.boards.active)
         Table.pick board.lists.backlog.cards
       end
 


### PR DESCRIPTION
Avoid asking user for board more than once for any given project.