### PR TITLE
Change trello_flow branch naming [Delivers #daHYUQbT]

### DIFF
--- a/lib/trello_flow/branch.rb
+++ b/lib/trello_flow/branch.rb
@@ -11,8 +11,8 @@ module TrelloFlow
       new Cli.read("git rev-parse --abbrev-ref HEAD")
     end
 
-    def self.from_card(card)
-      new("#{current.target}.#{card.to_param}.#{card.short_link}")
+    def self.from_card(user:, card:)
+      new("#{user.initials.downcase}.#{card.to_param}.#{current.target}.#{card.short_link}")
     end
 
     def checkout
@@ -36,7 +36,11 @@ module TrelloFlow
     end
 
     def target
-      name.split('.').first
+      if legacy_naming?
+        name_parts.first
+      else
+        name_parts[-2] || name
+      end
     end
 
     private
@@ -49,6 +53,14 @@ module TrelloFlow
 
       def card_short_link
         name[/\.(\w+)$/, 1]
+      end
+
+      def legacy_naming?
+        name_parts.size == 3
+      end
+
+      def name_parts
+        @_name_parts ||= name.split(".")
       end
   end
 end

--- a/lib/trello_flow/main.rb
+++ b/lib/trello_flow/main.rb
@@ -12,7 +12,7 @@ module TrelloFlow
       card = create_or_pick_card(name)
       card.add_member(current_user)
       card.start
-      Branch.from_card(card).checkout
+      Branch.from_card(user: current_user, card: card).checkout
     end
 
     def open

--- a/lib/trello_flow/version.rb
+++ b/lib/trello_flow/version.rb
@@ -1,3 +1,3 @@
 module TrelloFlow
-  VERSION = "3.3.0"
+  VERSION = "3.4.0"
 end


### PR DESCRIPTION
> Currently trello flow names branches like: `branch.description.card_id` but often branch is just `master` and therefore not really that useful. I propose making two changes. The first is to prefix branches with initials (so I can easily distinguish my branches) and the second is to move branch name towards the end.

> `initials.description.branch.card_id` or `initials.description.card_id.branch` that way I can read things in order of importance.