### PR TITLE
Show better error message Trello API returns an error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: ruby
 rvm:
-  - 2.2.2
-before_install: gem install bundler -v 1.11.2
+  - 2.3.3
+before_install: gem install bundler

--- a/lib/trello_flow/api/base.rb
+++ b/lib/trello_flow/api/base.rb
@@ -2,6 +2,9 @@ require "spyke"
 require "trello_flow/api/json_parser"
 require "trello_flow/api/error_handler"
 
+Faraday::Response.register_middleware json_parser: -> { TrelloFlow::Api::JSONParser }
+Faraday::Response.register_middleware error_handler: -> { TrelloFlow::Api::ErrorHandler }
+
 module TrelloFlow
   module Api
     class Base < Spyke::Base
@@ -16,10 +19,10 @@ module TrelloFlow
 
       def self.configure(key:, token:)
         self.connection = Faraday.new(url: "https://api.trello.com/1", params: { key: key, token: token }) do |c|
-          c.request   :json
-          c.use       ErrorHandler
-          c.use       JSONParser
-          c.adapter   Faraday.default_adapter
+          c.request  :json
+          c.response :json_parser
+          c.response :error_handler
+          c.adapter  Faraday.default_adapter
 
           # For trello api logging
           # require "faraday/conductivity"

--- a/lib/trello_flow/api/base.rb
+++ b/lib/trello_flow/api/base.rb
@@ -2,9 +2,6 @@ require "spyke"
 require "trello_flow/api/json_parser"
 require "trello_flow/api/error_handler"
 
-Faraday::Response.register_middleware json_parser: -> { TrelloFlow::Api::JSONParser }
-Faraday::Response.register_middleware error_handler: -> { TrelloFlow::Api::ErrorHandler }
-
 module TrelloFlow
   module Api
     class Base < Spyke::Base
@@ -20,8 +17,8 @@ module TrelloFlow
       def self.configure(key:, token:)
         self.connection = Faraday.new(url: "https://api.trello.com/1", params: { key: key, token: token }) do |c|
           c.request  :json
-          c.response :json_parser
-          c.response :error_handler
+          c.use JSONParser
+          c.use ErrorHandler
           c.adapter  Faraday.default_adapter
 
           # For trello api logging

--- a/lib/trello_flow/api/base.rb
+++ b/lib/trello_flow/api/base.rb
@@ -1,5 +1,6 @@
 require "spyke"
 require "trello_flow/api/json_parser"
+require "trello_flow/api/error_handler"
 
 module TrelloFlow
   module Api
@@ -16,6 +17,7 @@ module TrelloFlow
       def self.configure(key:, token:)
         self.connection = Faraday.new(url: "https://api.trello.com/1", params: { key: key, token: token }) do |c|
           c.request   :json
+          c.use       ErrorHandler
           c.use       JSONParser
           c.adapter   Faraday.default_adapter
 

--- a/lib/trello_flow/api/error.rb
+++ b/lib/trello_flow/api/error.rb
@@ -1,6 +1,5 @@
 module TrelloFlow
   module Api
     class Error < StandardError; end
-    class NotFound < Error; end
   end
 end

--- a/lib/trello_flow/api/error.rb
+++ b/lib/trello_flow/api/error.rb
@@ -1,0 +1,6 @@
+module TrelloFlow
+  module Api
+    class Error < StandardError; end
+    class NotFound < Error; end
+  end
+end

--- a/lib/trello_flow/api/error_handler.rb
+++ b/lib/trello_flow/api/error_handler.rb
@@ -1,0 +1,32 @@
+require "trello_flow/api/error"
+
+module TrelloFlow
+  module Api
+    class ErrorHandler < Faraday::Middleware
+      def call(env)
+        @app.call(env).on_complete do
+          status_code = env.status
+          response_body = env[:body]
+
+          if status_code == 404
+            raise NotFound, error_message(response_body)
+          end
+        end
+      end
+
+      private
+
+      def error_message(message)
+        if member_endpoint?(message)
+          "Verify your API key and token are correct at '~/.trello_flow'"
+        else
+          message
+        end
+      end
+
+      def member_endpoint?(message)
+        !!(message =~ /\/member/)
+      end
+    end
+  end
+end

--- a/lib/trello_flow/api/error_handler.rb
+++ b/lib/trello_flow/api/error_handler.rb
@@ -5,27 +5,10 @@ module TrelloFlow
     class ErrorHandler < Faraday::Middleware
       def call(env)
         @app.call(env).on_complete do
-          status_code = env.status
-          response_body = env[:body]
-
-          if status_code == 404
-            raise NotFound, error_message(response_body)
+          if !env.success?
+            raise TrelloFlow::Api::Error, env[:body]
           end
         end
-      end
-
-      private
-
-      def error_message(message)
-        if member_endpoint?(message)
-          "Verify your API key and token are correct at '~/.trello_flow'"
-        else
-          message
-        end
-      end
-
-      def member_endpoint?(message)
-        !!(message =~ /\/member/)
       end
     end
   end

--- a/lib/trello_flow/api/error_handler.rb
+++ b/lib/trello_flow/api/error_handler.rb
@@ -6,7 +6,7 @@ module TrelloFlow
       def call(env)
         @app.call(env).on_complete do
           if !env.success?
-            raise TrelloFlow::Api::Error, env[:body]
+            raise Error, env[:body]
           end
         end
       end

--- a/lib/trello_flow/main.rb
+++ b/lib/trello_flow/main.rb
@@ -10,14 +10,13 @@ module TrelloFlow
     end
 
     def start(name)
-      cli_error("Your `trello_flow` version is out of date. Please run `gem update trello_flow`.") unless Version.latest?
+      Cli.error "Your `trello_flow` version is out of date. Please run `gem update trello_flow`." unless Version.latest?
       card = create_or_pick_card(name)
       card.add_member(current_user)
       card.start
       Branch.from_card(user: current_user, card: card).checkout
-
-    rescue TrelloFlow::Api::Error => error
-      cli_error(error.message)
+    rescue Api::Error => error
+      Cli.error(error.message)
     end
 
     def open
@@ -65,10 +64,6 @@ module TrelloFlow
 
       def current_user
         @_current_user ||= Api::Member.current
-      end
-
-      def cli_error(message)
-        Cli.error(message)
       end
   end
 end

--- a/lib/trello_flow/main.rb
+++ b/lib/trello_flow/main.rb
@@ -10,11 +10,14 @@ module TrelloFlow
     end
 
     def start(name)
-      Cli.error "Your `trello_flow` version is out of date. Please run `gem update trello_flow`." unless Version.latest?
+      cli_error("Your `trello_flow` version is out of date. Please run `gem update trello_flow`.") unless Version.latest?
       card = create_or_pick_card(name)
       card.add_member(current_user)
       card.start
       Branch.from_card(user: current_user, card: card).checkout
+
+    rescue TrelloFlow::Api::Error => error
+      cli_error(error.message)
     end
 
     def open
@@ -62,6 +65,10 @@ module TrelloFlow
 
       def current_user
         @_current_user ||= Api::Member.current
+      end
+
+      def cli_error(message)
+        Cli.error(message)
       end
   end
 end

--- a/lib/trello_flow/version.rb
+++ b/lib/trello_flow/version.rb
@@ -1,5 +1,5 @@
 module TrelloFlow
-  VERSION = "3.5.0"
+  VERSION = "3.6.0"
   class Version
     def self.latest?
       new.latest?

--- a/lib/trello_flow/version.rb
+++ b/lib/trello_flow/version.rb
@@ -12,11 +12,15 @@ module TrelloFlow
     private
 
       def latest_version
-        @_latest_version ||= Gem.latest_version_for("trello_flow")
+        @_latest_version ||= Gem.latest_version_for("trello_flow") || first_version
       end
 
       def current_version
         @_current_version ||= Gem::Version.new(VERSION)
+      end
+
+      def first_version
+        @_first_version ||= Gem::Version.new("1.0.0")
       end
   end
 end

--- a/test/support/webmock.rb
+++ b/test/support/webmock.rb
@@ -1,12 +1,8 @@
 require 'webmock/minitest'
 
 class WebMock::RequestStub
-  def to_return_json(response, options = {})
-    if options[:status] == 404
-      options[:body] = response
-    else
-      options[:body] = MultiJson.dump(response)
-    end
+  def to_return_json(hash, options = {})
+    options[:body] = MultiJson.dump(hash)
     to_return(options)
   end
 end

--- a/test/support/webmock.rb
+++ b/test/support/webmock.rb
@@ -1,8 +1,12 @@
 require 'webmock/minitest'
 
 class WebMock::RequestStub
-  def to_return_json(hash, options = {})
-    options[:body] = MultiJson.dump(hash)
+  def to_return_json(response, options = {})
+    if options[:status] == 404
+      options[:body] = response
+    else
+      options[:body] = MultiJson.dump(response)
+    end
     to_return(options)
   end
 end

--- a/test/trello_flow_test.rb
+++ b/test/trello_flow_test.rb
@@ -5,7 +5,7 @@ module TrelloFlow
     def setup
       Cli.client = cli
       stub_trello(:get, "/tokens/MEMBER_TOKEN/member").to_return_json(member)
-      stub_request(:get, /api.rubygems.org/)
+      stub_request(:get, /api\.rubygems\.org/)
     end
 
     def test_git_start_from_url

--- a/test/trello_flow_test.rb
+++ b/test/trello_flow_test.rb
@@ -138,15 +138,15 @@ module TrelloFlow
     end
 
     def test_wrong_credentials
-      stub_trello(:get, "/tokens/WRONG_MEMBER_TOKEN/member").to_return(member_not_found)
-      cli.expect :error, "Verify your API key and token are correct at '~/.trello_flow'"
+      stub_trello(:get, "/boards/BOARD_ID").to_return(invalid_token)
+      cli.expect :error, nil, ["invalid token"]
       trello_flow.start(nil)
       cli.verify
     end
 
     def test_inexistent_card
-      stub_trello(:get, "/cards/CARD_SHORT_LINK").to_return(card_not_found)
-      cli.expect :error, resource_not_found[:body]
+      stub_trello(:get, "/cards/CARD_SHORT_LINK").to_return(invalid_card_id)
+      cli.expect :error, nil, ["invalid id"]
       trello_flow.start(card_url)
       cli.verify
     end
@@ -197,12 +197,12 @@ module TrelloFlow
         { id: "LABEL_ID", name: "LABEL NAME" }
       end
 
-      def member_not_found
-        { status: 404, body: "Cannot GET /1/tokens/WRONG_MEMBER_TOKEN/member" }
+      def invalid_token
+        { status: 400, body: "invalid token" }
       end
 
-      def card_not_found
-        { status: 404, body: "Cannot GET /1/cards/CARD_SHORT_LINK" }
+      def invalid_card_id
+        { status: 302, body: "invalid id" }
       end
 
       def cli

--- a/test/trello_flow_test.rb
+++ b/test/trello_flow_test.rb
@@ -5,6 +5,7 @@ module TrelloFlow
     def setup
       Cli.client = cli
       stub_trello(:get, "/tokens/MEMBER_TOKEN/member").to_return_json(member)
+      stub_request(:get, /api.rubygems.org/)
     end
 
     def test_git_start_from_url

--- a/test/trello_flow_test.rb
+++ b/test/trello_flow_test.rb
@@ -137,6 +137,13 @@ module TrelloFlow
       cli.verify
     end
 
+    def test_wrong_credentials
+      stub_trello(:get, "/tokens/WRONG_MEMBER_TOKEN/member").to_return_json(member_not_found, {status: 404})
+      cli.expect :error, "Verify your API key and token are correct at '~/.trello_flow'"
+      trello_flow.start(nil)
+      cli.verify
+    end
+
     private
 
       def card_short_link
@@ -181,6 +188,10 @@ module TrelloFlow
 
       def label
         { id: "LABEL_ID", name: "LABEL NAME" }
+      end
+
+      def member_not_found
+        "Cannot GET /1/tokens/WRONG_MEMBER_TOKEN/member"
       end
 
       def cli

--- a/test/trello_flow_test.rb
+++ b/test/trello_flow_test.rb
@@ -138,9 +138,16 @@ module TrelloFlow
     end
 
     def test_wrong_credentials
-      stub_trello(:get, "/tokens/WRONG_MEMBER_TOKEN/member").to_return_json(member_not_found, {status: 404})
+      stub_trello(:get, "/tokens/WRONG_MEMBER_TOKEN/member").to_return(member_not_found)
       cli.expect :error, "Verify your API key and token are correct at '~/.trello_flow'"
       trello_flow.start(nil)
+      cli.verify
+    end
+
+    def test_inexistent_card
+      stub_trello(:get, "/cards/CARD_SHORT_LINK").to_return(card_not_found)
+      cli.expect :error, resource_not_found[:body]
+      trello_flow.start(card_url)
       cli.verify
     end
 
@@ -191,7 +198,11 @@ module TrelloFlow
       end
 
       def member_not_found
-        "Cannot GET /1/tokens/WRONG_MEMBER_TOKEN/member"
+        { status: 404, body: "Cannot GET /1/tokens/WRONG_MEMBER_TOKEN/member" }
+      end
+
+      def card_not_found
+        { status: 404, body: "Cannot GET /1/cards/CARD_SHORT_LINK" }
       end
 
       def cli


### PR DESCRIPTION
Before this change `MultiJson::ParseError` was raised because currently Trello
API doesn't respons with a JSON body in that case.

The intention is to check if the response was not successful and return that error message to the user via the CLI instead of raising a confusing JSON parse exception.