### PR TITLE
Add option to rebase to target for git finish

### DIFF
--- a/exe/git-finish
+++ b/exe/git-finish
@@ -14,6 +14,7 @@ Usage:
     git finish
 EOS
   opt :wip, "Open [WIP] PR"
+  opt :rebase, "Rebase to master"
 end
 
 TrelloFlow::Main.new.finish(options)

--- a/lib/trello_flow.rb
+++ b/lib/trello_flow.rb
@@ -3,6 +3,7 @@ require "trello_flow/cli"
 require "trello_flow/table"
 require "trello_flow/branch"
 require "trello_flow/cleanup"
+require "trello_flow/update"
 require "trello_flow/main"
 
 module TrelloFlow

--- a/lib/trello_flow/branch.rb
+++ b/lib/trello_flow/branch.rb
@@ -27,8 +27,8 @@ module TrelloFlow
       Cli.run "git pull origin #{name}"
     end
 
-    def rebase(branch = "master")
-      Cli.run "git rebase #{branch}"
+    def rebase
+      Cli.run "git rebase #{target}"
     end
 
     def open_pull_request(options = {})

--- a/lib/trello_flow/branch.rb
+++ b/lib/trello_flow/branch.rb
@@ -27,8 +27,8 @@ module TrelloFlow
       Cli.run "git pull origin #{name}"
     end
 
-    def rebase_to_master
-      Cli.run "git rebase origin master"
+    def rebase(branch = "master")
+      Cli.run "git rebase #{branch}"
     end
 
     def open_pull_request(options = {})

--- a/lib/trello_flow/branch.rb
+++ b/lib/trello_flow/branch.rb
@@ -23,6 +23,14 @@ module TrelloFlow
       Cli.run "git push origin #{name} -u"
     end
 
+    def pull
+      Cli.run "git pull origin #{name}"
+    end
+
+    def rebase_to_master
+      Cli.run "git rebase origin master"
+    end
+
     def open_pull_request(options = {})
       PullRequest.new(current_card, options.merge(from: name, target: target)).open
     end

--- a/lib/trello_flow/main.rb
+++ b/lib/trello_flow/main.rb
@@ -24,9 +24,8 @@ module TrelloFlow
     end
 
     def finish(options = {})
-      update_master_branch
       branch = Branch.current
-      branch.rebase_to_master
+      Update.new(branch).run if options[:rebase]
       branch.push
       branch.open_pull_request(options)
     end
@@ -41,11 +40,6 @@ module TrelloFlow
 
       def board
         @_board ||= local_config.board
-      end
-
-      def update_master_branch
-        master_branch = Branch.new("master")
-        master_branch.pull
       end
 
       def create_or_pick_card(name)

--- a/lib/trello_flow/main.rb
+++ b/lib/trello_flow/main.rb
@@ -24,7 +24,9 @@ module TrelloFlow
     end
 
     def finish(options = {})
+      update_master_branch
       branch = Branch.current
+      branch.rebase_to_master
       branch.push
       branch.open_pull_request(options)
     end
@@ -39,6 +41,11 @@ module TrelloFlow
 
       def board
         @_board ||= local_config.board
+      end
+
+      def update_master_branch
+        master_branch = Branch.new("master")
+        master_branch.pull
       end
 
       def create_or_pick_card(name)

--- a/lib/trello_flow/update.rb
+++ b/lib/trello_flow/update.rb
@@ -1,0 +1,18 @@
+module TrelloFlow
+  class Update
+    def initialize(branch)
+      @feature_branch = branch
+      @master_branch = Branch.new("master")
+    end
+
+    def run
+      master_branch.checkout
+      master_branch.pull
+      feature_branch.checkout
+      feature_branch.rebase
+    end
+
+    private
+      attr_reader :feature_branch, :master_branch
+  end
+end

--- a/lib/trello_flow/update.rb
+++ b/lib/trello_flow/update.rb
@@ -2,17 +2,17 @@ module TrelloFlow
   class Update
     def initialize(branch)
       @feature_branch = branch
-      @master_branch = Branch.new("master")
+      @target_branch = Branch.new(branch.target)
     end
 
     def run
-      master_branch.checkout
-      master_branch.pull
+      target_branch.checkout
+      target_branch.pull
       feature_branch.checkout
       feature_branch.rebase
     end
 
     private
-      attr_reader :feature_branch, :master_branch
+      attr_reader :feature_branch, :target_branch
   end
 end

--- a/test/trello_flow_test.rb
+++ b/test/trello_flow_test.rb
@@ -101,6 +101,8 @@ module TrelloFlow
     def test_git_finish
       card_endpoint = stub_trello(:get, "/cards/CARD_SHORT_LINK").to_return_json(card)
 
+      cli.expect :run, nil, ["git pull origin master"]
+      cli.expect :run, nil, ["git rebase origin master"]
       cli.expect :read, "jb.card-name.master.CARD_SHORT_LINK", ["git rev-parse --abbrev-ref HEAD"]
       cli.expect :run, nil, ["git push origin jb.card-name.master.CARD_SHORT_LINK -u"]
       cli.expect :read, "git@github.com:balvig/trello_flow.git", ["git config --get remote.origin.url"]
@@ -115,6 +117,8 @@ module TrelloFlow
     def test_git_finish_with_backwards_compatibility
       stub_trello(:get, "/cards/CARD_SHORT_LINK").to_return_json(card)
 
+      cli.expect :run, nil, ["git pull origin master"]
+      cli.expect :run, nil, ["git rebase origin master"]
       cli.expect :read, "master.card-name.CARD_SHORT_LINK", ["git rev-parse --abbrev-ref HEAD"]
       cli.expect :run, nil, ["git push origin master.card-name.CARD_SHORT_LINK -u"]
       cli.expect :read, "git@github.com:balvig/trello_flow.git", ["git config --get remote.origin.url"]
@@ -128,6 +132,8 @@ module TrelloFlow
     def test_finish_wip
       stub_trello(:get, "/cards/CARD_SHORT_LINK").to_return_json(card)
 
+      cli.expect :run, nil, ["git pull origin master"]
+      cli.expect :run, nil, ["git rebase origin master"]
       cli.expect :read, "jb.card-name.master.CARD_SHORT_LINK", ["git rev-parse --abbrev-ref HEAD"]
       cli.expect :run, nil, ["git push origin jb.card-name.master.CARD_SHORT_LINK -u"]
       cli.expect :read, "git@github.com:balvig/trello_flow.git", ["git config --get remote.origin.url"]


### PR DESCRIPTION
Add an option to rebase to target before pushing the branch. 
```
» .git-finish --help
Pushes branch to GitHub and opens a PR

Usage:
    git finish
  -w, --wip       Open [WIP] PR
  -r, --rebase    Rebase to master
  -h, --help      Show this message
```