### PR TITLE
Update depedency name

### DIFF
--- a/cp8_cli.gemspec
+++ b/cp8_cli.gemspec
@@ -34,6 +34,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "launchy"
   spec.add_dependency "octokit"
   spec.add_dependency "thor"
-  spec.add_dependency "trollop"
+  spec.add_dependency "optimist"
   spec.add_dependency "tty-prompt"
 end

--- a/exe/git-finish
+++ b/exe/git-finish
@@ -3,10 +3,10 @@
 $LOAD_PATH.unshift File.join(File.dirname(__FILE__), '..', 'lib')
 
 require "cp8_cli"
-require "trollop"
+require "optimist"
 
 
-options = Trollop::options do
+options = Optimist::options do
 	banner <<-EOS
 Pushes branch to GitHub and opens a PR
 


### PR DESCRIPTION
Closes https://github.com/cookpad/cp8_cli/issues/29

Recently `trollop` got renamed to `optimist`. This renames the
dependency and gets rid of the deprecation warning we are currently
getting:

```rb
Fetching: trollop-2.9.9.gem (100%)
!    The 'trollop' gem has been deprecated and has been replaced by 'optimist'.
!    See: https://rubygems.org/gems/optimist
!    And: https://github.com/ManageIQ/optimist
```