### PR TITLE
replace WIP PRs with draft PRs

### DIFF
--- a/lib/cp8_cli/github/pull_request.rb
+++ b/lib/cp8_cli/github/pull_request.rb
@@ -35,7 +35,9 @@ module Cp8Cli
           to,
           from,
           title,
-          body
+          body,
+          draft: true,
+          accept: "application/vnd.github.shadow-cat-preview" # waiting for https://github.com/octokit/octokit.rb/pull/1114
         )
       end
 

--- a/lib/cp8_cli/pull_request_title.rb
+++ b/lib/cp8_cli/pull_request_title.rb
@@ -2,7 +2,7 @@ module Cp8Cli
   class PullRequestTitle
     def initialize(title, prefixes: [])
       @title = title
-      @prefixes = Array(*prefixes)
+      @prefixes = Array(prefixes)
     end
 
     def run

--- a/lib/cp8_cli/story.rb
+++ b/lib/cp8_cli/story.rb
@@ -6,9 +6,9 @@ module Cp8Cli
       checkout_branch
       create_empty_commit
       push_branch
-      create_wip_pull_request
+      create_draft_pull_request
       assign
-      Command.title "Created WIP PR, run `cp8 open` to view."
+      Command.title "Created draft PR, run `cp8 open` to view."
     end
 
     private
@@ -33,10 +33,10 @@ module Cp8Cli
         branch.push
       end
 
-      def create_wip_pull_request
+      def create_draft_pull_request
         Github::PullRequest.create(
           from: branch.name,
-          title: PullRequestTitle.new(title, prefixes: :wip).run,
+          title: PullRequestTitle.new(title).run,
           body: PullRequestBody.new(self).run
         )
       end

--- a/lib/cp8_cli/version.rb
+++ b/lib/cp8_cli/version.rb
@@ -1,5 +1,5 @@
 module Cp8Cli
-  VERSION = "8.2.1"
+  VERSION = "9.0.0"
 
   class Version
     def self.latest?

--- a/test/main_test.rb
+++ b/test/main_test.rb
@@ -10,7 +10,7 @@ module Cp8Cli
 
     def test_start_adhoc_story
       pr_endpoint = stub_github(:post, "/repos/balvig/cp8_cli/pulls").
-        with(body: { base: "master", head: "jb/fix-bug", title: "[WIP] Fix bug" })
+        with(body: { base: "master", head: "jb/fix-bug", title: "Fix bug", draft: true })
 
       stub_github_user("John Bobson")
       stub_repo("git@github.com:balvig/cp8_cli.git")
@@ -19,7 +19,7 @@ module Cp8Cli
       expect_checkout("jb/fix-bug")
       expect_commit("Fix bug")
       expect_push("jb/fix-bug")
-      expect_title "Created WIP PR, run `cp8 open` to view."
+      expect_title "Created draft PR, run `cp8 open` to view."
 
       cli.start("Fix bug")
 
@@ -38,8 +38,9 @@ module Cp8Cli
         body: {
           base: "master",
           head: "jb/issue-title",
-          title: "[WIP] ISSUE TITLE",
+          title: "ISSUE TITLE",
           body: "Closes balvig/cp8_cli#ISSUE_NUMBER\n\n_Release note: ISSUE TITLE_",
+          draft: true
         }
       )
 
@@ -54,7 +55,7 @@ module Cp8Cli
       expect_checkout("jb/issue-title")
       expect_commit("ISSUE TITLE")
       expect_push("jb/issue-title")
-      expect_title "Created WIP PR, run `cp8 open` to view."
+      expect_title "Created draft PR, run `cp8 open` to view."
 
       cli.start("https://github.com/balvig/cp8_cli/issues/ISSUE_NUMBER")
 


### PR DESCRIPTION
Replaces our `[WIP] PR Title` approach with using actual draft pull requests.
Companion to https://github.com/cookpad/cp8/pull/84.