### PR TITLE
Tag initial commits so they skip CI

### DIFF
--- a/lib/cp8_cli/story.rb
+++ b/lib/cp8_cli/story.rb
@@ -18,7 +18,7 @@ module Cp8Cli
       end
 
       def create_empty_commit
-        Command.run "git commit --allow-empty -m#{commit_message}", title: "Creating initial commit"
+        Command.run "git commit --allow-empty -m#{commit_message} #{skip_ci}", title: "Creating initial commit"
       end
 
       def commit_message
@@ -27,6 +27,10 @@ module Cp8Cli
 
       def escaped_title
         Shellwords.escape(title)
+      end
+
+      def skip_ci
+        "-m'[skip ci]'"
       end
 
       def push_branch

--- a/test/support/command.rb
+++ b/test/support/command.rb
@@ -25,7 +25,7 @@ def expect_checkout(branch)
 end
 
 def expect_commit(message)
-  expected_command = "git commit --allow-empty -m#{Shellwords.escape(message)}"
+  expected_command = "git commit --allow-empty -m#{Shellwords.escape(message)} -m'[skip ci]'"
   shell.expect :run, nil, [expected_command, { title: "Creating initial commit" }]
 end
 


### PR DESCRIPTION
I'd like it so that CircleCI is not triggered on the initial commit / empty PR, as per this guide:

https://circleci.com/docs/2.0/skip-build/

The format of the commit message (double -m args) is inspired by this post: https://stackoverflow.com/a/22909204

What do you think? 😄 