### PR TITLE
Add info about personal access token asked by gem

### DIFF
--- a/lib/cp8_cli/global_config.rb
+++ b/lib/cp8_cli/global_config.rb
@@ -21,7 +21,10 @@ module Cp8Cli
       end
 
       def configure_github_token
-        store.save :github_token, Command.ask("Input GitHub token (https://github.com/settings/tokens)")
+        store.save(
+          :github_token,
+          Command.ask("Input GitHub access token with repo access scope (https://github.com/settings/tokens):")
+        )
       end
   end
 end


### PR DESCRIPTION
cp8 requires a GitHub token and doesn't say which privileges are required for it to function correctly. it's confusing for dev newly using it 🙇 