### PR TITLE
Use OS dependent open command

### DIFF
--- a/cp8_cli.gemspec
+++ b/cp8_cli.gemspec
@@ -35,4 +35,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "octokit", "~> 4.18"
   spec.add_dependency "thor"
   spec.add_dependency "tty-prompt"
+  spec.add_dependency "os"
 end

--- a/lib/cp8_cli/command.rb
+++ b/lib/cp8_cli/command.rb
@@ -2,6 +2,7 @@ require "colored"
 require "active_support/core_ext/module/delegation"
 require "highline"
 require "tty-prompt"
+require "os"
 
 module Cp8Cli
   class Command
@@ -14,7 +15,7 @@ module Cp8Cli
 
     def open_url(url)
       return title(url) if ENV['BROWSER'] == 'echo'
-      `open \"#{url}\"`
+      `#{OS.open_file_command} \"#{url}\"`
     end
 
     def title(message)


### PR DESCRIPTION
Closes #47 

I hope the addition of a new dependency is okay, it just looked like the correct way to add a cross-platform way to open a browser.

This is the first time I've done anything with ruby, might not be the right way to do things.