### PR TITLE
Rename config file to ~/.cp8_cli

### DIFF
--- a/lib/cp8_cli/config_store.rb
+++ b/lib/cp8_cli/config_store.rb
@@ -10,9 +10,18 @@ module Cp8Cli
       data[key]
     end
 
+    def exist?
+      File.exist?(path)
+    end
+
+    def move_to(new_path)
+      File.rename(path, new_path)
+      @path = new_path
+    end
+
     def save(key, value)
       data[key] = value
-      File.new(path, "w") unless File.exists?(path)
+      File.new(path, "w") unless exist?
       File.open(path, "w") { |f| f.write(data.to_yaml) }
       value
     end

--- a/lib/cp8_cli/global_config.rb
+++ b/lib/cp8_cli/global_config.rb
@@ -2,10 +2,11 @@ require "cp8_cli/config_store"
 
 module Cp8Cli
   class GlobalConfig
-    PATH = ENV["HOME"] + "/.trello_flow"
+    LEGACY_PATH = ENV["HOME"] + "/.trello_flow"
+    PATH = ENV["HOME"] + "/.cp8_cli"
 
     def initialize(store = nil)
-      @store = store || ConfigStore.new(PATH)
+      @store = store || initialize_store
     end
 
     def github_token
@@ -15,6 +16,29 @@ module Cp8Cli
     private
 
       attr_reader :store
+
+      def initialize_store
+        migrate_legacy_store if uses_legacy_store?
+
+        default_store
+      end
+
+      def uses_legacy_store?
+        !default_store.exist? && legacy_store.exist?
+      end
+
+      def migrate_legacy_store
+        Command.say("#{LEGACY_PATH} was deprecated, moving to #{PATH}")
+        legacy_store.move_to(PATH)
+      end
+
+      def default_store
+        @_default_store ||= ConfigStore.new(PATH)
+      end
+
+      def legacy_store
+        @_legacy_store ||= ConfigStore.new(LEGACY_PATH)
+      end
 
       def env_github_token
         ENV["OCTOKIT_ACCESS_TOKEN"]

--- a/lib/cp8_cli/global_config.rb
+++ b/lib/cp8_cli/global_config.rb
@@ -24,7 +24,7 @@ module Cp8Cli
       end
 
       def uses_legacy_store?
-        !default_store.exist? && legacy_store.exist?
+        legacy_store.exist?
       end
 
       def migrate_legacy_store


### PR DESCRIPTION
# What

This renames the file used to store configuration from `.trello_flow` to `.cp8_cli` and provides an automated migration path for existing users.

 # Why

The original file name, `.trello_flow`, is tied to the gem's original name and may not ring a bell to recent users.
I myself accidentally deleted `.trello_flow` a few days ago while doing some cleanup and thinking I was not using "Trello Flow" anymore. 😬 

 # How

- If the user has a `.trello_flow` file, then rename it to `.cp8_cli` and use it.
- Use `.cp8_cli` file.

 # Anything else?

Wasn't sure how one would handle deprecation in the future, but I imagine the migration logic can just be removed after a few months.

I've also made an alternative PR, which changes are _slightly_ simpler, but reinforce the dependency between `GlobalConfig` and `ConfigStore`'s implementation details (for instance, using the `File` class and knowing more about the presence of files).
https://github.com/cookpad/cp8_cli/compare/master...davidstosik:rename-store-2?expand=1
Let me know if that simpler version is preferable. 🙏🏻 

(Bonus: this commit could remove `GlobalConfig` dependency on the file system: https://github.com/davidstosik/cp8_cli/commit/9e83ae745a9ce24cf6440b9039e0c555e9e2ca25)