### PR TITLE
Fix last argument warnings on Ruby 2.7+

### DIFF
--- a/lib/cp8_cli/github/issue.rb
+++ b/lib/cp8_cli/github/issue.rb
@@ -16,7 +16,7 @@ module Cp8Cli
       def self.find_by_url(url)
         url = ParsedUrl.new(url)
         issue = client.issue(url.repo, url.number).to_h
-        new issue.merge(number: url.number, repo: url.repo)
+        new(**issue.merge(number: url.number, repo: url.repo))
       end
 
       def title

--- a/lib/cp8_cli/github/pull_request.rb
+++ b/lib/cp8_cli/github/pull_request.rb
@@ -7,12 +7,12 @@ module Cp8Cli
       include Api::Client
 
       def self.create(attributes = {})
-        new(attributes).save
+        new(**attributes).save
       end
 
       def self.find_by(repo:, branch:)
         client.pull_requests(repo.shorthand, head: "#{repo.user}:#{branch}").map do |data|
-          new(data)
+          new(**data)
         end.first
       end
 


### PR DESCRIPTION
This commit fixes these warning when run `rake test` in Ruby 2.7+

    [PROJECT_DIR]/lib/cp8_cli/github/pull_request.rb:10: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
    [PROJECT_DIR]/lib/cp8_cli/github/pull_request.rb:19: warning: The called method `initialize' is defined here
    [PROJECT_DIR]/lib/cp8_cli/github/issue.rb:19: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
    [PROJECT_DIR]/lib/cp8_cli/github/issue.rb:10: warning: The called method `initialize' is defined here
    [PROJECT_DIR]/lib/cp8_cli/github/pull_request.rb:15: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
    [PROJECT_DIR]/lib/cp8_cli/github/pull_request.rb:19: warning: The called method `initialize' is defined here