### PR TITLE
Add support for repositories which no longer use `master` as their default branch name

### DIFF
--- a/exe/cp8
+++ b/exe/cp8
@@ -27,7 +27,7 @@ module Cp8Cli
       main.ci
     end
 
-    desc "suggest", "Creates a suggestion branch from new commits, pushes it, opens URL and resets `master` back to `origin/master`."
+    desc "suggest", "Creates a suggestion branch from new commits, pushes it, opens URL, and resets the base branch."
     def suggest
       main.suggest
     end

--- a/lib/cp8_cli/github/pull_request.rb
+++ b/lib/cp8_cli/github/pull_request.rb
@@ -16,9 +16,9 @@ module Cp8Cli
         end.first
       end
 
-      def initialize(from: nil, to: "master", title: nil, body: nil, expand: 1, html_url: nil, **attributes)
+      def initialize(from: nil, to: nil, title: nil, body: nil, expand: 1, html_url: nil, **attributes)
         @from = from
-        @to = to
+        @to = to || default_branch
         @title = title
         @body = body
         @expand = expand
@@ -44,6 +44,10 @@ module Cp8Cli
       private
 
         attr_reader :from, :to, :title, :body, :expand, :html_url
+
+        def default_branch
+          client.repo(repo.shorthand).default_branch
+        end
 
         def url
           html_url || new_pr_url

--- a/test/main_test.rb
+++ b/test/main_test.rb
@@ -9,6 +9,7 @@ module Cp8Cli
     end
 
     def test_start_adhoc_story
+      stub_github(:get, "/repos/balvig/cp8_cli").to_return_json(github_repo)
       pr_endpoint = stub_github(:post, "/repos/balvig/cp8_cli/pulls").
         with(body: { base: "master", head: "jb/fix-bug", title: "Fix bug", draft: true })
 
@@ -34,6 +35,7 @@ module Cp8Cli
     end
 
     def test_start_github_issue
+      stub_github(:get, "/repos/balvig/cp8_cli").to_return_json(github_repo)
       create_pr_endpoint = stub_github(:post, "/repos/balvig/cp8_cli/pulls").with(
         body: {
           base: "master",
@@ -68,6 +70,7 @@ module Cp8Cli
     end
 
     def test_open_master
+      stub_github(:get, "/repos/balvig/cp8_cli").to_return_json(github_repo)
       stub_branch("master")
       stub_repo("git@github.com:balvig/cp8_cli.git")
       stub_repo("git@github.com:balvig/cp8_cli.git") # erm
@@ -85,6 +88,7 @@ module Cp8Cli
     end
 
     def test_open_branch
+      stub_github(:get, "/repos/balvig/cp8_cli").to_return_json(github_repo)
       stub_branch("jb/adhoc-story")
       stub_repo("git@github.com:balvig/cp8_cli.git")
       stub_repo("git@github.com:balvig/cp8_cli.git") # erm
@@ -102,11 +106,13 @@ module Cp8Cli
     end
 
     def test_submit_branch_with_pr
+      stub_github(:get, "/repos/balvig/cp8_cli").to_return_json(github_repo)
       find_pr_endpoint = stub_github(:get, "/repos/balvig/cp8_cli/pulls").
         with(query: { head: "balvig:jb/fix-bug" }).
         to_return_json([github_pr])
       stub_branch("jb/fix-bug")
       stub_repo("git@github.com:balvig/cp8_cli.git")
+      stub_repo("git@github.com:balvig/cp8_cli.git") # erm
 
       expect_push("jb/fix-bug")
 
@@ -120,6 +126,7 @@ module Cp8Cli
     end
 
     def test_submit_plain_branch
+      stub_github(:get, "/repos/balvig/cp8_cli").to_return_json(github_repo)
       stub_branch("fix-this")
       stub_repo("git@github.com:balvig/cp8_cli.git")
       stub_repo("git@github.com:balvig/cp8_cli.git") # erm
@@ -173,6 +180,10 @@ module Cp8Cli
 
       def label
         { id: "LABEL_ID", name: "LABEL NAME" }
+      end
+
+      def github_repo
+        { default_branch: "master" }
       end
 
       def github_pr

--- a/test/main_test.rb
+++ b/test/main_test.rb
@@ -90,8 +90,7 @@ module Cp8Cli
     def test_open_branch
       stub_github(:get, "/repos/balvig/cp8_cli").to_return_json(github_repo)
       stub_branch("jb/adhoc-story")
-      stub_repo("git@github.com:balvig/cp8_cli.git")
-      stub_repo("git@github.com:balvig/cp8_cli.git") # erm
+      stub_repo("git@github.com:balvig/cp8_cli.git", count: 2)
 
       expect_pr(
         repo: "balvig/cp8_cli",
@@ -111,8 +110,7 @@ module Cp8Cli
         with(query: { head: "balvig:jb/fix-bug" }).
         to_return_json([github_pr])
       stub_branch("jb/fix-bug")
-      stub_repo("git@github.com:balvig/cp8_cli.git")
-      stub_repo("git@github.com:balvig/cp8_cli.git") # erm
+      stub_repo("git@github.com:balvig/cp8_cli.git", count: 2)
 
       expect_push("jb/fix-bug")
 
@@ -128,8 +126,7 @@ module Cp8Cli
     def test_submit_plain_branch
       stub_github(:get, "/repos/balvig/cp8_cli").to_return_json(github_repo)
       stub_branch("fix-this")
-      stub_repo("git@github.com:balvig/cp8_cli.git")
-      stub_repo("git@github.com:balvig/cp8_cli.git") # erm
+      stub_repo("git@github.com:balvig/cp8_cli.git", count: 2)
 
       expect_push("fix-this")
       expect_pr(

--- a/test/support/command.rb
+++ b/test/support/command.rb
@@ -12,8 +12,8 @@ def stub_github_user(name)
   shell.expect :read, name, ["git config user.name"]
 end
 
-def stub_repo(repo)
-  shell.expect :read, repo, ["git config --get remote.origin.url"]
+def stub_repo(repo, count: 1)
+  count.times { shell.expect(:read, repo, ["git config --get remote.origin.url"]) }
 end
 
 def stub_branch(branch)


### PR DESCRIPTION
This PR updates the pull request mechanic to call GitHub API and asks for default branch name to be use as the base branch, as suggested in https://github.com/cookpad/cp8_cli/pull/51#issuecomment-779305468

I also added another commit to cleanup `stub_repo` method to make it accepts `:count` arguments for when we have to stub the call to get the local repository information multiple times.