### PR TITLE
Silence Faraday deprecation warnings

### DIFF
--- a/cp8_cli.gemspec
+++ b/cp8_cli.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "colored"
   spec.add_dependency "highline"
   spec.add_dependency "launchy"
-  spec.add_dependency "octokit", "~> 4.18"
+  spec.add_dependency "octokit", "~> 4.22"
   spec.add_dependency "thor"
   spec.add_dependency "tty-prompt"
   spec.add_dependency "os"

--- a/cp8_cli.gemspec
+++ b/cp8_cli.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "colored"
   spec.add_dependency "highline"
   spec.add_dependency "launchy"
-  spec.add_dependency "octokit", "~> 4.22"
+  spec.add_dependency "octokit", "~> 4.21"
   spec.add_dependency "thor"
   spec.add_dependency "tty-prompt"
   spec.add_dependency "os"

--- a/lib/cp8_cli/version.rb
+++ b/lib/cp8_cli/version.rb
@@ -1,5 +1,5 @@
 module Cp8Cli
-  VERSION = "9.1.0"
+  VERSION = "9.1.1"
 
   class Version
     def self.latest?


### PR DESCRIPTION
## What

Bumps Octokit version to 4.21

## Why

This should remove warnings issued by recent versions of Faraday:

```
WARNING: `Faraday::Connection#authorization` is deprecated; it will be removed in version 2.0.        
While initializing your connection, use `#request(:authorization, ...)` instead.                      
See https://lostisland.github.io/faraday/middleware/authentication for more usage info.
```

See https://github.com/octokit/octokit.rb/pull/1359

## How

Simple gemspec bump.

Note that there are [some murmurings about compatibility with GitHub Enterprise](https://github.com/octokit/octokit.rb/issues/1391) with `v 4.22`, so for now have pointed it to `4.21`.

## Anything else

Hope everything is well at Cookpad! ❤️